### PR TITLE
Update CCS-720XP-96ZC2-2F.yaml

### DIFF
--- a/device-types/Arista/CCS-720XP-96ZC2-2F.yaml
+++ b/device-types/Arista/CCS-720XP-96ZC2-2F.yaml
@@ -184,35 +184,35 @@ interfaces:
     poe_mode: pse
     poe_type: type3-ieee802.3bt
   - name: Ethernet41
-    type: 2.5gbase-t
+    type: 5gbase-t
     poe_mode: pse
     poe_type: type3-ieee802.3bt
   - name: Ethernet42
-    type: 2.5gbase-t
+    type: 5gbase-t
     poe_mode: pse
     poe_type: type3-ieee802.3bt
   - name: Ethernet43
-    type: 2.5gbase-t
+    type: 5gbase-t
     poe_mode: pse
     poe_type: type3-ieee802.3bt
   - name: Ethernet44
-    type: 2.5gbase-t
+    type: 5gbase-t
     poe_mode: pse
     poe_type: type3-ieee802.3bt
   - name: Ethernet45
-    type: 2.5gbase-t
+    type: 5gbase-t
     poe_mode: pse
     poe_type: type3-ieee802.3bt
   - name: Ethernet46
-    type: 2.5gbase-t
+    type: 5gbase-t
     poe_mode: pse
     poe_type: type3-ieee802.3bt
   - name: Ethernet47
-    type: 2.5gbase-t
+    type: 5gbase-t
     poe_mode: pse
     poe_type: type3-ieee802.3bt
   - name: Ethernet48
-    type: 2.5gbase-t
+    type: 5gbase-t
     poe_mode: pse
     poe_type: type3-ieee802.3bt
   - name: Ethernet49
@@ -344,35 +344,35 @@ interfaces:
     poe_mode: pse
     poe_type: type3-ieee802.3bt
   - name: Ethernet81
-    type: 5gbase-t
+    type: 2.5gbase-t
     poe_mode: pse
     poe_type: type3-ieee802.3bt
   - name: Ethernet82
-    type: 5gbase-t
+    type: 2.5gbase-t
     poe_mode: pse
     poe_type: type3-ieee802.3bt
   - name: Ethernet83
-    type: 5gbase-t
+    type: 2.5gbase-t
     poe_mode: pse
     poe_type: type3-ieee802.3bt
   - name: Ethernet84
-    type: 5gbase-t
+    type: 2.5gbase-t
     poe_mode: pse
     poe_type: type3-ieee802.3bt
   - name: Ethernet85
-    type: 5gbase-t
+    type: 2.5gbase-t
     poe_mode: pse
     poe_type: type3-ieee802.3bt
   - name: Ethernet86
-    type: 5gbase-t
+    type: 2.5gbase-t
     poe_mode: pse
     poe_type: type3-ieee802.3bt
   - name: Ethernet87
-    type: 5gbase-t
+    type: 2.5gbase-t
     poe_mode: pse
     poe_type: type3-ieee802.3bt
   - name: Ethernet88
-    type: 5gbase-t
+    type: 2.5gbase-t
     poe_mode: pse
     poe_type: type3-ieee802.3bt
   - name: Ethernet89


### PR DESCRIPTION
YAML file mistakenly lists ports 81-96 as 5G ports, when in reality the 5G ports are 41-48 and 89-96

![image](https://github.com/user-attachments/assets/17159149-792f-4e5e-90cd-3fbee63ce70f)
